### PR TITLE
RFC: Add tool definitions to publisher extensions

### DIFF
--- a/rfcs/THV-0015-tool-definitions-extension.md
+++ b/rfcs/THV-0015-tool-definitions-extension.md
@@ -1,4 +1,4 @@
-# RFC: Add Tool Definitions to Publisher Extensions
+# RFC-0015: Add Tool Definitions to Publisher Extensions
 
 > **Note**: This was originally [THV-2733](https://github.com/stacklok/toolhive/pull/2733) in the toolhive repository.
 


### PR DESCRIPTION
## Summary

Port proposal from [toolhive PR #2733](https://github.com/stacklok/toolhive/pull/2733).

This RFC proposes adding comprehensive tool metadata to the existing ToolHive publisher extension (`io.github.stacklok`) in the upstream MCP Registry format. This extends beyond simple tool names to include full MCP tool definitions with descriptions, input/output schemas, and annotations.

## What's Changing

- Adds `tool_definitions` field to the existing `io.github.stacklok` publisher extension
- Stores full MCP tool metadata: name, title, description, inputSchema, outputSchema, annotations
- Maintains backward compatibility with existing `tools` string array

## Use Cases

1. **Enhanced tooling output** - `thv list` can show tool descriptions
2. **API contract breakage detection** - Compare schemas to detect breaking changes in server updates
3. **Client integrations** - IDEs/editors can display tool signatures and validate inputs

## Technical Details

- Reuses existing extension namespace (no new namespaces)
- Aligns with [MCP specification tool schema](https://modelcontextprotocol.io/specification/2025-06-18/server/tools)
- Optional field - servers without it continue to work
- Type-safe deserialization using existing converter patterns