### PR TITLE
RFC: Shared key authentication for local MCP servers

### DIFF
--- a/rfcs/THV-0016-localhost-shared-key-auth.md
+++ b/rfcs/THV-0016-localhost-shared-key-auth.md
@@ -1,4 +1,4 @@
-# RFC: Shared Key Authentication for Local MCP Servers
+# RFC-0016: Shared Key Authentication for Local MCP Servers
 
 > **Note**: This was originally [THV-2570](https://github.com/stacklok/toolhive/pull/2570) in the toolhive repository.
 


### PR DESCRIPTION
## Summary

Port proposal from [toolhive PR #2570](https://github.com/stacklok/toolhive/pull/2570).

This proposal introduces a lightweight authentication mechanism for localhost MCP server deployments that provides defense-in-depth security without requiring external identity providers.

## Overview

The proposal adds shared key authentication as an opt-in feature for local ToolHive deployments. While localhost binding provides network-level security, this adds an additional authentication layer for defense-in-depth.

## Key Features

- Cryptographically-secure shared key generation per workload (32-byte keys)
- OS keychain storage via existing encrypted secrets provider
- New middleware for constant-time key validation
- Transparent integration with `thv proxy stdio` bridge
- Zero-configuration UX: just add `--shared-key-auth` flag
- Backward compatible (opt-in feature)

## Architecture

The solution leverages existing ToolHive infrastructure:
- **Key storage**: Uses existing encrypted secrets provider and OS keychain integration
- **Middleware**: Follows standard middleware pattern for clean integration
- **Stdio bridge**: Enhances existing proxy to inject authentication headers
- **Workload manager**: Handles key lifecycle automatically

## Security Properties

- 256-bit cryptographic keys via `crypto/rand`
- AES-256-GCM encrypted storage in OS keychain
- Constant-time comparison to prevent timing attacks
- Defense-in-depth layer (complements network isolation)
- Unique key per workload with automatic cleanup

## Usage Example

```bash
# Enable shared key auth
thv run my-server --shared-key-auth

# ToolHive automatically:
# 1. Generates secure key
# 2. Stores in OS keychain
# 3. Configures middleware
# 4. Updates client config
```