### PR TITLE
Improve `README.md` and `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ should help you get started.
 - [Code of conduct](#code-of-conduct)
 - [Reporting security vulnerabilities](#reporting-security-vulnerabilities)
 - [How to contribute](#how-to-contribute)
-  - [Using GitHub Issues and Discussions](#using-github-issues-and-discussions)
+  - [Using Discord Threads](#using-github-issues-and-discussions)
   - [Not sure how to start contributing?](#not-sure-how-to-start-contributing)
   - [RFC submission process](#rfc-submission-process)
   - [RFC file naming format](#rfc-file-naming-format)
@@ -35,11 +35,15 @@ follow this
 
 ## How to contribute
 
-### Using GitHub Issues and Discussions
+### Using Discord Threads
 
-We use GitHub Discussions for RFC ideas and general design conversations. If you
-have an idea for a significant change but aren't sure if it warrants an RFC,
-start a discussion first.
+You can reach out to the team using [Discord](https://discord.gg/stacklok),
+which we use for all our interactions with users and contributors, and also
+for RFC ideas and general design conversations. To avoid confusion, we
+recommend using Discord threads, this will make easier to follow conversations.
+
+If you have an idea for a significant change but aren't sure if it warrants an
+RFC, start a thread first.
 
 GitHub Issues in this repository are used to track RFC status and any
 meta-discussions about the RFC process itself.
@@ -52,18 +56,17 @@ For general usage questions about ToolHive, please ask in
 If you're new to the RFC process:
 
 1. Read through existing RFCs to understand the format and level of detail expected
-2. Start with a GitHub Discussion to validate your idea
+2. Start with a thread on [Discord](https://discord.gg/stacklok) to validate your idea
 3. Review the [RFC template](rfcs/0000-template.md) to understand what sections are required
-4. Reach out on [Discord](https://discord.gg/stacklok) if you have questions
 
 ### RFC submission process
 
-1. **Start a discussion (optional but recommended)**: Open a GitHub Discussion
+1. **Start a thread (optional but recommended)**: Open a thread on Discord
    to gather initial feedback on your idea before investing time in a full RFC.
 
 2. **Fork and create your RFC**:
    - Fork this repository to your own GitHub account
-   - Copy `rfcs/0000-template.md` to `rfcs/XXXX-descriptive-name.md`
+   - Copy `rfcs/0000-template.md` to `rfcs/THV-XXXX-descriptive-name.md`
    - Use the next available RFC number (check existing RFCs)
    - Fill in all required sections of the template
 
@@ -89,17 +92,19 @@ If you're new to the RFC process:
 All RFC files must follow this naming pattern:
 
 ```
-{NUMBER}-{descriptive-name}.md
+THV-{NUMBER}-{descriptive-name}.md
 ```
 
 Where:
-- `{NUMBER}` is a four-digit sequential number (e.g., 0001, 0002)
+- `{NUMBER}` is a four-digit sequential number that must be equal to the PR number (e.g., 0001, 0002)
 - `{descriptive-name}` is a short description in kebab-case
 
 #### Examples of valid RFC names:
-- `0001-token-exchange-middleware.md`
-- `0002-kubernetes-crd-improvements.md`
-- `0003-registry-api-v2.md`
+- `THV-0001-token-exchange-middleware.md`
+- `THV-0002-kubernetes-crd-improvements.md`
+- `THV-0003-registry-api-v2.md`
+
+A CI job will make sure you're following the right numbering.
 
 ### RFC content guidelines
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ This RFC repository serves the entire ToolHive ecosystem, including but not limi
 
 ### 1. Pre-RFC Discussion (Optional)
 
-Before writing a full RFC, consider opening a [GitHub Discussion](https://github.com/stacklok/toolhive-rfcs/discussions) to gather initial feedback on your idea. This can help refine the proposal before investing time in a full RFC.
+Before writing a full RFC, consider opening a thread on [Discord](https://discord.gg/stacklok) to gather initial feedback on your idea. This can help refine the proposal before investing time in a full RFC.
 
 ### 2. Create the RFC
 
 1. Fork this repository
 2. Copy `rfcs/0000-template.md` to `rfcs/XXXX-descriptive-name.md`
-   - Use the next available RFC number (check existing RFCs)
+   - Use the next available Pull Request number for your RFC (check existing RFCs)
    - Use a short, descriptive name with hyphens
 3. Fill in the RFC template
 4. Submit a Pull Request
@@ -76,7 +76,7 @@ Once accepted, the RFC can be implemented. The RFC should be updated with:
 
 ## RFC Numbering
 
-RFCs are numbered sequentially (0001, 0002, etc.). When creating a new RFC, check the existing RFCs and use the next available number.
+RFCs are numbered based on the PR numbers, so they are incremental, but not necessarily sequential (0001, 0002, 0004, etc.). When creating a new RFC, check the existing RFCs and use the next available number. A CI task will ensure you're using the right number.
 
 For RFCs that originate from issues in specific repositories, you may reference the issue number in the RFC (e.g., "This RFC addresses toolhive#1234").
 


### PR DESCRIPTION
This PR removes references to GitHub Discussions replacing them with Discord threads. It also clarifies the naming convention to follow.