### PR TITLE
Add auth server design proposals

### DIFF
--- a/rfcs/THV-0019-auth-server-design.md
+++ b/rfcs/THV-0019-auth-server-design.md
@@ -1,0 +1,242 @@
+# OAuth Authorization Server Design
+
+This document covers the implementation of the ToolHive OAuth Authorization
+Server. A separate design document covers the overall backend authentication
+approach and rationale.
+
+## Problem Statement
+
+MCP servers need to authenticate users and obtain their upstream identity for API access. The auth server must implement OAuth 2.0 flows, integrate with upstream IDPs, issue JWTs, and manage sessions with upstream tokens for later retrieval by vMCP.
+
+## Goals
+
+- Implement OAuth 2.0 Authorization Code Flow with PKCE (RFC 7636)
+- Integrate with upstream OIDC Identity Providers
+- Issue signed JWTs for authenticated sessions
+- Provide dynamic client registration (RFC 7591)
+- Expose OIDC discovery and JWKS endpoints
+- Abstract storage for horizontal scaling (with practical implementations being in-memory or Redis)
+
+## Non-Goals
+
+- Full OIDC Provider certification (we implement the subset needed for MCP use case)
+
+## Architecture Overview
+
+The auth server is built on Fosite, a mature OAuth 2.0/OIDC library, with
+custom handlers for upstream IDP integration and session management.
+
+```mermaid
+flowchart TB
+    subgraph AuthServer["Auth Server"]
+        subgraph Endpoints["HTTP Endpoints"]
+            authorize["/authorize"]
+            token["/token"]
+            callback["/callback"]
+        end
+
+        subgraph Fosite["Fosite OAuth Provider"]
+            pkce["PKCE validation"]
+            tokissue["Token issuance"]
+            session["Session management"]
+            clientauth["Client authentication"]
+        end
+
+        subgraph Backend["Backend Services"]
+            storage["Storage<br/>(mem/Redis)"]
+            idpclient["Upstream<br/>IDP Client"]
+            signing["Signing<br/>Keys"]
+        end
+
+        authorize --> Fosite
+        token --> Fosite
+        callback --> Fosite
+        Fosite --> storage
+        Fosite --> idpclient
+        Fosite --> signing
+    end
+```
+
+## Detailed Design
+
+### 1. OAuth 2.0 Endpoints
+
+The auth server exposes standard OAuth 2.0 and OIDC endpoints for client interaction and token management.
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/oauth/authorize` | GET | Authorization endpoint - initiates flow, generates PKCE challenge |
+| `/oauth/callback` | GET | Callback from upstream IDP - exchanges upstream code for tokens |
+| `/oauth/token` | POST | Token endpoint - exchanges authorization code for access/refresh tokens |
+| `/oauth/register` | POST | Dynamic client registration (RFC 7591) |
+| `/.well-known/openid-configuration` | GET | OIDC discovery document |
+| `/.well-known/jwks.json` | GET | JSON Web Key Set for token validation |
+
+### 2. Authorization Code Flow with PKCE
+
+All authorization flows require PKCE (S256 method) for security. The flow begins when a client redirects to `/oauth/authorize` with a code challenge.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant AS as Auth Server
+    participant IDP as Upstream IDP
+
+    Client->>AS: GET /oauth/authorize<br/>code_challenge, redirect_uri, state
+    AS-->>Client: 302 Redirect to IDP
+
+    Client->>IDP: User authenticates
+    IDP-->>Client: 302 to Auth Server /callback
+
+    Client->>AS: GET /oauth/callback<br/>code, state
+    AS->>IDP: POST /token
+    IDP-->>AS: IDP tokens<br/>(access, refresh, id_token)
+    AS-->>Client: 302 to client with auth code
+
+    Client->>AS: POST /oauth/token<br/>code, code_verifier
+    AS-->>Client: JWT tokens (with tsid claim)
+```
+
+### 3. Upstream IDP Integration
+
+The auth server acts as a client to upstream identity providers such as Google, GitHub, and others. It fetches the IDP's discovery document, constructs authorization URLs, and exchanges codes for tokens. Each IDP is configured with an issuer URL, client ID, client secret, and requested scopes. When the user authenticates, the auth server receives the access token, refresh token, and ID token from the upstream IDP and stores them for later retrieval by vMCP or backend MCP servers.
+
+Upstream ID tokens must be cryptographically verified before trusting their claims. The auth server fetches and caches the upstream IDP's JWKS, retrieved from the `jwks_uri` specified in the IDP's discovery document. The standard OIDC claims (`iss`, `aud`, `exp`, `iat`, `nonce`) are validated according to the OIDC specification to ensure token integrity and prevent replay attacks.
+
+### 4. JWT Token Issuance
+
+The auth server issues its own JWTs for client authentication. Clients present
+these JWTs to ToolHive, which validates them and uses the `tsid` claim to
+retrieve stored upstream IDP tokens.
+
+**Token claims:**
+```json
+{
+  "iss": "https://auth.toolhive.example.com",
+  "sub": "user@example.com",
+  "aud": "mcp-server",
+  "exp": 1234567890,
+  "iat": 1234567890,
+  "tsid": "session-uuid-here"
+}
+```
+
+JWTs are signed using ECDSA (ES256, preferred) or RSA (RS256) keys. The algorithm is auto-derived from the key type. ES256 is recommended for new deployments due to smaller signatures and faster operations; RS256 is supported for OIDC compliance per [Section 15.1](https://openid.net/specs/openid-connect-core-1_0.html#ServerMTI). Public keys are exposed via the JWKS endpoint for verification, with the OIDC discovery document dynamically advertising the configured algorithm.
+
+### 5. Session Management
+
+Sessions store the complete authentication state including upstream IDP tokens. The `tsid` (token session ID) in issued JWTs references these sessions.
+
+The session data includes:
+- User subject and claims from upstream ID token
+- Client ID and redirect URI
+- Upstream access token, refresh token, ID token
+- Token expiration timestamps
+- Refresh token family ID for rotation tracking
+
+### 6. Refresh Token Rotation
+
+Refresh tokens are rotated on each use to detect token replay attacks. When a refresh token is used, a new one is issued and the old one is invalidated. All refresh tokens in a session share a family ID, allowing the auth server to detect replay attempts—if an old refresh token is reused, the entire family is revoked, invalidating all tokens in that session. When a client refreshes its tokens, the auth server also refreshes the upstream IDP tokens if they have expired.
+
+### 7. Token Revocation (RFC 7009) - Future
+
+The `/oauth/revoke` endpoint will accept both access and refresh tokens and invalidate them. Revoking a refresh token cascades to invalidate all related access tokens. Optionally, revocation can also cascade to delete the stored upstream IDP tokens associated with the session.
+
+### 8. Dynamic Client Registration (RFC 7591)
+
+Clients can register dynamically via POST to `/oauth/register`. This returns a client ID and optional client secret.
+
+**Registration metadata:**
+- `redirect_uris`: Allowed callback URLs
+- `grant_types`: Supported grant types (default: `authorization_code`, `refresh_token`)
+- `response_types`: Supported response types (default: `code`)
+- `client_name`: Human-readable name
+
+### 9. Storage Abstraction
+
+Storage is abstracted behind interfaces to support different backends. In-memory storage is suitable for development; Redis is required for production multi-replica deployments.
+
+**Storage interfaces:**
+- `AuthorizationCodeStorage`: Stores authorization codes with PKCE verifiers
+- `AccessTokenStorage`: Stores access token metadata
+- `RefreshTokenStorage`: Stores refresh tokens with family tracking
+- `SessionStorage`: Stores complete session state including IDP tokens
+- `ClientStorage`: Stores registered client configurations
+
+## Integration
+
+The auth server is implemented as `pkg/authserver` and can be embedded into `thv` or run standalone.
+
+**Embedded Mode** (MVP): The auth server exposes an `http.Handler` that serves all OAuth/OIDC endpoints. This handler is mounted in the `thv` HTTP server under `/oauth/`.
+
+**Standalone Mode** (future): The auth server can run as a separate service with its own HTTP server.
+
+## Data Model
+
+### Session
+
+```go
+type Session struct {
+    ID              string
+    Subject         string
+    ClientID        string
+    IDPAccessToken  string
+    IDPRefreshToken string
+    IDPIDToken      string
+    IDPTokenExpiry  time.Time
+    RefreshFamily   string
+    CreatedAt       time.Time
+    ExpiresAt       time.Time
+}
+```
+
+### Client
+
+```go
+type Client struct {
+    ID            string
+    SecretHash    []byte
+    RedirectURIs  []string
+    GrantTypes    []string
+    ResponseTypes []string
+    Metadata      map[string]string
+}
+```
+
+## Security Considerations
+
+- **PKCE required**: No implicit flow; all authorization requests must include PKCE
+- **State validation**: CSRF protection via state parameter
+- **ID token verification**: Upstream ID tokens verified against JWKS before trusting
+- **Nonce validation**: Replay protection for ID tokens
+- **Secret management**: Signing keys and client secrets stored securely
+- **Rate limiting**: Authentication endpoints protected against brute force
+
+## Configuration Example
+
+```yaml
+auth_server:
+  issuer: "https://auth.toolhive.example.com"
+
+  upstream_idp:
+    issuer: "https://accounts.google.com"
+    client_id: "your-client-id"
+    client_secret_env: "IDP_CLIENT_SECRET"
+    scopes: ["openid", "profile", "email"]
+
+  signing:
+    # Optional: if omitted, a key is auto-generated and persisted to storage
+    key_file: "/etc/toolhive/signing-key.pem"
+    # Optional: auto-derived from key type (ES256 for EC, RS256 for RSA)
+    algorithm: "ES256"
+
+  storage:
+    type: "redis"  # or "memory"
+    redis:
+      address: "redis:6379"
+
+  tokens:
+    access_token_lifetime: "1h"
+    refresh_token_lifetime: "24h"
+    authorization_code_lifetime: "10m"
+```

--- a/rfcs/THV-0019-auth-server-overview.md
+++ b/rfcs/THV-0019-auth-server-overview.md
@@ -1,0 +1,142 @@
+# OAuth Authorization Server for ToolHive - Overview
+
+## Problem Statement
+
+ToolHive MCP servers need to authenticate users via OAuth/OIDC and obtain
+their upstream identity for API access. Users authenticate with upstream
+Identity Providers (Google, GitHub, Atlassian, etc.) and MCP servers need to
+call those upstream APIs on behalf of users.
+
+Currently, there is no implemented way to handle user authentication to
+upstream IDPs or upstream IDP token pass-through across MCP servers and vMCP.
+
+## Why an Authorization Server?
+
+### The Redirect URI and Client ID/Client Secret Problem
+
+OAuth 2.0 requires pre-registered redirect URIs at each Identity Provider. Moreover
+many IDPs (Google, GitHub, etc.) require manual registration of OAuth clients in order
+to obtain Client ID and Client Secret.
+
+If each user client (e.g. an IDE) were its own OAuth client, the registration
+burden would be too high. Moreover, each client comes with its own redirect URI.
+
+### How a Centralized AS Solves This
+
+With ToolHive's Authorization Server:
+
+```mermaid
+flowchart LR
+    User --> AS[ToolHive AS]
+    AS --> IDP[Upstream IDP<br/>GitHub, Google, Atlassian]
+    IDP --> AS
+    AS --> Store[(Tokens stored)]
+    Store --> MCP[MCP Server]
+    AS -->|JWT with tsid claim| User
+```
+
+### Dynamic Client Registration (RFC 7591)
+
+MCP clients can **self-register** with ToolHive's AS via Dynamic Client Registration. This
+enables self-service onboarding of clients without admin intervention.
+
+**Note**: DCR works for clients → ToolHive AS, but not for ToolHive → upstream
+IDPs (Google, GitHub, etc. require manual OAuth client registration).
+
+**Future Enhancement**: The MCP 2025-11-25 specification recommends Client ID
+Metadata Documents as the preferred client registration method over DCR. In this
+approach, clients use HTTPS URLs as client identifiers (e.g.,
+`https://app.example.com/oauth/client-metadata.json`) that the authorization
+server fetches and validates dynamically. We will implement DCR first for the
+MVP, then migrate to Client ID Metadata Documents in a later phase to align with
+the MCP specification's recommended priority order.
+
+## Use Cases
+
+### Google Docs MCP Server
+> As a user, I want to authenticate to a Google Docs MCP server and only be able to access my own documents. The MCP server should effectively impersonate me when calling Google APIs.
+
+### GitHub MCP Server
+> As a developer, I want to authenticate to a GitHub MCP server so I can create PRs, manage issues, and access repositories using my own GitHub identity and permissions.
+
+### Multi-Backend Workflow (vMCP)
+> As a platform engineer, I want to deploy vMCP so that users authenticate once and vMCP retrieves their upstream IDP tokens to pass through to multiple backend MCP servers (GitHub, Jira, Slack).
+
+## Backend Authentication Approach
+
+The MCP authorization spec covers authorization **to** the MCP server but not how MCP servers authenticate **to upstream services**. While RFC 8693 token exchange and federated IDPs (e.g., Google Workforce Identity Federation) work when the upstream service is in the same trust domain, many MCP servers need to access external services like GitHub, Google, or Atlassian APIs where no federation exists.
+
+This design implements an **OAuth Authorization Server** that:
+1. Authenticates users against the upstream IDP (GitHub, Google, Atlassian, etc.)
+2. Stores the upstream IDP tokens
+3. Issues its own JWT with a `tsid` claim linking to the stored tokens
+4. Enables vMCP and MCP servers to retrieve and use the upstream tokens
+
+**Note**: A future enhancement may add an internal company IDP hop before the external IDP, enabling enterprise identity linking. The current implementation goes directly to the external IDP.
+
+## Goals
+
+- Provide OAuth 2.0 for authentication to MCP servers
+- Integrate with upstream OIDC Identity Providers (Google, GitHub, Atlassian, Okta, Azure AD)
+- Issue signed JWTs to clients
+- Integrate with Kubernetes operator via CRDs
+- Enable vMCP to retrieve and pass through upstream IDP tokens
+- Support Dynamic Client Registration (RFC 7591) for MCP clients
+- Support both embedded and centralized deployment modes, starting with embedded
+
+## Non-Goals
+
+- Full OIDC Provider certification
+- Acting as a general-purpose OAuth server for non-MCP use cases
+
+## Architecture Overview
+
+The auth server acts as an intermediary between clients and upstream IDPs, issuing its own JWTs while storing upstream tokens for later retrieval.
+
+```mermaid
+flowchart TB
+    subgraph ToolHive["ToolHive Ecosystem"]
+        Client[Client]
+        AS[Auth Server]
+        Store[(Token Store)]
+        MCP["MCP Server / vMCP<br/>• Validates JWT via JWKS<br/>• Retrieves IDP tokens via tsid<br/>• Passes tokens to upstream APIs"]
+    end
+
+    IDP[Upstream IDP<br/>GitHub, Google, Atlassian]
+
+    Client <--> AS
+    AS <--> IDP
+    AS -->|Store IDP tokens| Store
+    Client -->|JWT| MCP
+    Store -->|Retrieve tokens| MCP
+```
+
+## Token Flow Summary
+
+1. **Client initiates OAuth flow** - Client redirects to auth server's `/oauth/authorize` with PKCE challenge
+2. **Upstream IDP authentication** - Auth server redirects to upstream IDP (GitHub, Google, etc.); user authenticates
+3. **Callback and token exchange** - Auth server receives callback, exchanges code with upstream IDP
+4. **JWT issuance** - Auth server issues its own JWT with `tsid` claim linking to stored IDP tokens
+5. **MCP server access** - Client presents JWT to MCP server; server validates via JWKS
+6. **vMCP token pass-through** - vMCP extracts `tsid`, retrieves IDP tokens, passes to backend APIs
+
+## Deployment Modes
+
+In the interest of ease of installation and operation, we will initially
+support an embedded deployment mode where the auth server runs in the same process
+as the MCP server proxy. This mode is suitable for simple MCP server deployments.
+
+However, in the interest of scalability and security, we'll move to a centralized
+or distributed deployment mode where a standalone auth server services multiple MCP
+servers. This will allow for better separation of concerns and allow to secure the AS better
+as well as scale it independently.
+
+## Implementation Steps
+
+| Step                                         | Scope                                                    |
+|----------------------------------------------|----------------------------------------------------------|
+| **1: MVP**                                   | Core OAuth flow, in-memory storage, K8s integration, DCR |
+| **2: Persistence & Security**                | Redis storage, refresh token utilization rotation        |
+| **3: vMCP Support**                          | Token pass-through middleware, session lookup            |
+| **4: Productization and operationalization** | Rate limiting, Observability, Auditing                   |
+| **5: Centralized Deployment**                | Standalone mode, multi-replica support                   |


### PR DESCRIPTION
MCP servers need to authenticate users via OAuth/OIDC and obtain upstream identity tokens to call external APIs (GitHub, Google, Atlassian) on behalf of users. OAuth 2.0 requires pre-registered redirect URIs and client credentials at each Identity Provider, making it impractical for individual user clients to register directly. A centralized Authorization Server solves this by acting as the single registered OAuth client with upstream IDPs, enabling Dynamic Client Registration for MCP clients while managing the complexity of upstream token storage and retrieval.

The solution implements an OAuth Authorization Server built on Fosite that authenticates users against upstream IDPs, stores their tokens, and issues its own JWTs with a tsid claim linking to the stored credentials. The server exposes standard OAuth 2.0/OIDC endpoints including authorization with PKCE, token exchange, dynamic client registration (RFC 7591), and JWKS for token validation. MCP servers and vMCP can then validate incoming JWTs and retrieve the upstream IDP tokens via the tsid to make authenticated API calls on behalf of users.

The design documents in this commit outline the solution in detail.
