### PR TITLE
Add Claude Code skills for RFC writing and review

### DIFF
--- a/.claude/skills/review-rfc/SKILL.md
+++ b/.claude/skills/review-rfc/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: review-rfc
+description: Review RFCs for the ToolHive ecosystem. Use when the user wants to review, critique, or provide feedback on an RFC for toolhive, toolhive-studio, toolhive-registry, toolhive-registry-server, toolhive-cloud-ui, or dockyard projects.
+allowed-tools: Read, Glob, Grep, Bash(git:*), mcp__github__*, mcp__fetch__fetch, WebFetch, Task
+---
+
+# Review RFC Skill
+
+This skill helps you thoroughly review RFCs for the ToolHive ecosystem, ensuring they meet quality standards, architectural alignment, and security requirements.
+
+## Overview
+
+When reviewing an RFC, you should evaluate it against multiple dimensions: completeness, technical accuracy, architectural alignment, security considerations, and feasibility.
+
+## Review Workflow
+
+### Step 1: Read the RFC
+
+First, read the RFC document completely. If provided a PR number or file path, fetch and read it.
+
+### Step 2: Fetch Architectural Context
+
+Before reviewing, gather context from the ToolHive architecture documentation. Use `mcp__github__get_file_contents` to read relevant docs from `stacklok/toolhive` repo's `docs/arch/` directory:
+
+| Document | When to Read |
+|----------|--------------|
+| `00-overview.md` | Always - understand platform concepts |
+| `01-deployment-modes.md` | RFCs affecting deployment, K8s, or local mode |
+| `02-core-concepts.md` | RFCs introducing new concepts or terminology |
+| `03-transport-architecture.md` | RFCs affecting MCP transports or proxy |
+| `04-secrets-management.md` | RFCs involving secrets or credentials |
+| `05-runconfig-and-permissions.md` | RFCs affecting configuration or permissions |
+| `06-registry-system.md` | RFCs affecting registry functionality |
+| `07-groups.md` | RFCs involving server grouping |
+| `08-workloads-lifecycle.md` | RFCs affecting workload management |
+| `09-operator-architecture.md` | RFCs affecting K8s operator or CRDs |
+| `10-virtual-mcp-architecture.md` | RFCs involving aggregation or virtual MCP |
+
+### Step 3: Check Related Existing RFCs
+
+Search this repository for related RFCs that might:
+- Conflict with the proposal
+- Be superseded by the proposal
+- Provide context or dependencies
+
+### Step 4: Verify Against Target Repository
+
+Search the target repository to verify:
+- Proposed changes align with existing code patterns
+- No conflicts with recent changes
+- API changes are compatible with existing interfaces
+
+## Review Checklist
+
+### A. Structure and Completeness
+
+- [ ] **Metadata present**: Status, Author, Created, Last Updated, Target Repository
+- [ ] **Summary**: Clear 2-3 sentence description
+- [ ] **Problem Statement**: Clearly articulates the problem, who's affected, why it matters
+- [ ] **Goals**: Specific, measurable objectives listed
+- [ ] **Non-Goals**: Explicit scope boundaries defined
+- [ ] **Proposed Solution**: Detailed design with diagrams where appropriate
+- [ ] **Security Considerations**: All required subsections present (see below)
+- [ ] **Alternatives Considered**: At least one alternative evaluated
+- [ ] **Compatibility**: Backward and forward compatibility addressed
+- [ ] **Implementation Plan**: Phased approach with concrete tasks
+- [ ] **Testing Strategy**: Multiple test levels covered
+- [ ] **Open Questions**: Unresolved items listed (if any)
+
+### B. Security Review (CRITICAL)
+
+The Security Considerations section MUST address all of these:
+
+| Section | Questions to Verify |
+|---------|---------------------|
+| **Threat Model** | Are potential threats identified? Are attacker capabilities considered? |
+| **Authentication** | How does this affect auth? Are new auth requirements clear? |
+| **Authorization** | What permission checks are needed? Any new permission models? |
+| **Data Security** | Is sensitive data identified? Is encryption addressed? |
+| **Input Validation** | What user input is accepted? How is it validated? |
+| **Secrets Management** | Are secrets handled properly? Can they be rotated? |
+| **Audit and Logging** | Are security events logged? Compliance considered? |
+| **Mitigations** | Are concrete mitigations proposed for identified threats? |
+
+**Red flags to watch for:**
+- Missing or superficial security section
+- "N/A" without justification for security subsections
+- No threat model for network-exposed features
+- Secrets in configuration examples
+- Missing input validation for user-provided data
+- No audit logging for security-relevant operations
+
+### C. Technical Accuracy
+
+- [ ] **Correct terminology**: Uses ToolHive concepts correctly (Workloads, Transports, Middleware, etc.)
+- [ ] **Architecture alignment**: Follows established patterns and principles
+- [ ] **Code examples**: Syntactically correct, idiomatic for the language
+- [ ] **API design**: Consistent with existing APIs in the target repo
+- [ ] **CRD design**: Follows Kubernetes conventions if applicable
+- [ ] **Configuration format**: Matches existing RunConfig patterns
+
+### D. Diagrams and Examples
+
+- [ ] **Mermaid diagrams**: Complex flows illustrated clearly
+- [ ] **Code examples**: Concrete, not abstract placeholders
+- [ ] **Configuration examples**: Realistic YAML/JSON examples
+- [ ] **Sequence diagrams**: For multi-component interactions
+
+### E. Feasibility and Impact
+
+- [ ] **Implementation complexity**: Is the phased approach realistic?
+- [ ] **Dependencies**: Are external dependencies identified?
+- [ ] **Breaking changes**: Are migration paths provided if needed?
+- [ ] **Performance impact**: Considered where relevant?
+- [ ] **Cross-repo impact**: If `multiple` repos, are all impacts identified?
+
+## ToolHive Ecosystem Context
+
+### Target Repositories
+
+| Repository | Type | Key Considerations |
+|------------|------|-------------------|
+| `toolhive` | Go | Core platform, CLI, operator, proxy, virtual MCP |
+| `toolhive-studio` | TypeScript | Desktop UI, Electron app |
+| `toolhive-registry-server` | Go | Registry API, MCP Registry spec compliance |
+| `toolhive-registry` | Go/JSON | Registry data, server definitions |
+| `toolhive-cloud-ui` | TypeScript/Next.js | Cloud UI, OIDC integration |
+| `dockyard` | Go | Container packaging, security scanning |
+
+### Key Architecture Principles to Verify
+
+1. **Platform, not runner**: Does this enhance the platform abstraction?
+2. **Security by default**: Does this maintain or improve security posture?
+3. **Middleware composability**: Can this be implemented as middleware if appropriate?
+4. **RunConfig portability**: Does this preserve configuration portability?
+5. **Cloud-native**: Is this Kubernetes-friendly where applicable?
+
+### CRD Types (for K8s-related RFCs)
+
+- `MCPServer` - Individual MCP server deployment
+- `MCPRegistry` - Registry configuration
+- `MCPToolConfig` - Tool filtering and configuration
+- `MCPExternalAuthConfig` - External authentication
+- `MCPGroup` - Server grouping
+- `VirtualMCPServer` - Aggregation of multiple servers
+
+## Review Output Format
+
+Structure your review as follows:
+
+```markdown
+## RFC Review: [RFC Title]
+
+### Summary
+[1-2 sentence summary of your overall assessment]
+
+### Strengths
+- [What the RFC does well]
+
+### Areas for Improvement
+
+#### Critical Issues (Must Fix)
+- [Issues that must be addressed before acceptance]
+
+#### Suggestions (Should Consider)
+- [Improvements that would strengthen the RFC]
+
+#### Minor/Nitpicks (Optional)
+- [Small improvements or style suggestions]
+
+### Security Assessment
+[Specific feedback on the security section]
+
+### Architectural Alignment
+[How well does this align with ToolHive architecture?]
+
+### Questions for the Author
+- [Clarifying questions that need answers]
+
+### Recommendation
+[ ] Ready to accept
+[ ] Accept with minor changes
+[ ] Needs revision (address critical issues)
+[ ] Major rework needed
+```
+
+## Common Issues to Watch For
+
+### Problem Statement Issues
+- Too vague or abstract
+- Doesn't explain who benefits
+- Problem already solved elsewhere
+
+### Design Issues
+- Over-engineered for the problem
+- Missing error handling considerations
+- Doesn't consider edge cases
+- Breaks existing functionality without migration path
+
+### Security Issues
+- Missing threat model
+- Hardcoded credentials in examples
+- No input validation
+- Missing audit logging
+- Overly permissive defaults
+
+### Implementation Issues
+- Unrealistic phasing
+- Missing dependencies
+- No rollback plan
+- Insufficient testing strategy
+
+## Reference Files
+
+- Template: `rfcs/0000-template.md`
+- Contributing guide: `CONTRIBUTING.md`
+- Existing RFCs: `rfcs/THV-*.md`

--- a/.claude/skills/write-rfc/SKILL.md
+++ b/.claude/skills/write-rfc/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: write-rfc
+description: Write RFCs for the ToolHive ecosystem. Use when the user wants to create a new RFC, proposal, or design document for toolhive, toolhive-studio, toolhive-registry, toolhive-registry-server, toolhive-cloud-ui, or dockyard projects.
+allowed-tools: Read, Glob, Grep, Bash(git:*), mcp__github__*, mcp__fetch__fetch, WebFetch, Task, Edit, Write, AskUserQuestion
+---
+
+# Write RFC Skill
+
+This skill helps you write high-quality RFCs for the ToolHive ecosystem following established patterns and conventions.
+
+## Overview
+
+ToolHive RFCs follow a specific format with the naming convention `THV-{NUMBER}-{descriptive-name}.md`. The NUMBER must match the PR number and be zero-padded to 4 digits.
+
+## Workflow
+
+### Step 1: Gather Requirements
+
+Before writing an RFC, ask the user about:
+
+1. **Problem Statement**: What problem are they trying to solve?
+2. **Target Repository**: Which repo does this affect?
+   - `toolhive` - Core runtime, CLI (`thv`), operator (`thv-operator`), proxy-runner (`thv-proxyrunner`), virtual MCP (`vmcp`)
+   - `toolhive-studio` - Desktop UI application (Electron/TypeScript)
+   - `toolhive-registry` - MCP server registry data
+   - `toolhive-registry-server` - Registry API server (`thv-registry-api`)
+   - `toolhive-cloud-ui` - Cloud/Enterprise web UI (Next.js)
+   - `dockyard` - Container packaging for MCP servers
+   - `multiple` - Cross-cutting changes
+3. **Scope**: What are the goals and explicit non-goals?
+
+### Step 2: Research the Ecosystem
+
+Before drafting, research the relevant codebase:
+
+#### 2.1 Fetch Architectural Documentation
+
+Use `mcp__github__get_file_contents` to read from `stacklok/toolhive` repo's `docs/arch/` directory:
+
+| Document | Content |
+|----------|---------|
+| `00-overview.md` | Platform overview, key components |
+| `01-deployment-modes.md` | Local vs Kubernetes modes |
+| `02-core-concepts.md` | Nouns (Workloads, Transports, Proxy, etc.) and Verbs |
+| `03-transport-architecture.md` | stdio, SSE, streamable-http transports |
+| `04-secrets-management.md` | Secrets handling, providers |
+| `05-runconfig-and-permissions.md` | Configuration format, permission profiles |
+| `06-registry-system.md` | Registry architecture, MCPRegistry CRD |
+| `07-groups.md` | Server grouping concepts |
+| `08-workloads-lifecycle.md` | Lifecycle management |
+| `09-operator-architecture.md` | K8s operator, CRDs |
+| `10-virtual-mcp-architecture.md` | Virtual MCP aggregation |
+
+#### 2.2 Review Existing RFCs
+
+Read `rfcs/` directory in this repository to understand patterns and check for related proposals.
+
+#### 2.3 Search Relevant Codebases
+
+Use `mcp__github__search_code` or `mcp__github__get_file_contents` to explore:
+
+| Repository | Purpose |
+|------------|---------|
+| `stacklok/toolhive` | Core platform, CLI, operator, proxy |
+| `stacklok/toolhive-studio` | Desktop UI |
+| `stacklok/toolhive-registry-server` | Registry API server |
+| `stacklok/toolhive-registry` | Registry data |
+| `stacklok/toolhive-cloud-ui` | Cloud/Enterprise UI |
+| `stacklok/dockyard` | Container packaging |
+
+### Step 3: Draft the RFC
+
+Create the RFC following the template structure from `rfcs/0000-template.md`.
+
+#### Required Metadata
+
+```markdown
+# RFC-XXXX: Title
+
+- **Status**: Draft
+- **Author(s)**: Name (@github-handle)
+- **Created**: YYYY-MM-DD
+- **Last Updated**: YYYY-MM-DD
+- **Target Repository**: [from step 1]
+- **Related Issues**: [links if applicable]
+```
+
+#### Core Sections
+
+1. **Summary** - 2-3 sentences capturing the essence
+2. **Problem Statement** - Current limitation, who's affected, why it matters
+3. **Goals** - Specific objectives (bulleted)
+4. **Non-Goals** - Explicit scope boundaries
+5. **Proposed Solution**
+   - High-Level Design (with Mermaid diagrams)
+   - Detailed Design: Component changes, API changes, configuration changes, data model changes
+6. **Security Considerations** (REQUIRED) - See security checklist below
+7. **Alternatives Considered** - Other approaches evaluated
+8. **Compatibility** - Backward and forward compatibility
+9. **Implementation Plan** - Phased approach with tasks
+10. **Testing Strategy** - Unit, integration, E2E, performance, security tests
+11. **Documentation** - What needs documenting
+12. **Open Questions** - Unresolved items
+13. **References** - Related links
+
+#### Security Considerations Checklist (REQUIRED)
+
+Every RFC MUST address:
+
+- [ ] **Threat Model** - Potential threats, attacker capabilities
+- [ ] **Authentication and Authorization** - Auth changes, permission models
+- [ ] **Data Security** - Sensitive data handling, encryption
+- [ ] **Input Validation** - User input, injection vectors
+- [ ] **Secrets Management** - Credentials storage, rotation
+- [ ] **Audit and Logging** - Security events, compliance
+- [ ] **Mitigations** - Security controls implemented
+
+### Step 4: Use Proper Conventions
+
+#### Code Examples
+
+- Use **Go** for API changes in toolhive, toolhive-registry-server
+- Use **TypeScript** for toolhive-studio, toolhive-cloud-ui changes
+- Use **YAML** for configuration examples
+- Use **Mermaid** for diagrams (flowcharts, sequence diagrams)
+
+#### Kubernetes CRDs
+
+If the RFC involves Kubernetes, include CRD examples:
+
+```yaml
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: example
+spec:
+  # ...
+```
+
+CRD types: `MCPServer`, `MCPRegistry`, `MCPToolConfig`, `MCPExternalAuthConfig`, `MCPGroup`, `VirtualMCPServer`
+
+### Step 5: File Naming
+
+The RFC file should be named `THV-XXXX-{descriptive-name}.md` where XXXX is the PR number. Since you don't know the PR number yet, use a placeholder like `THV-XXXX-{name}.md` and remind the user to rename it to match the PR number after creating the PR.
+
+### Step 6: Review Checklist
+
+Before finalizing, verify:
+
+- [ ] Problem is clearly stated
+- [ ] Goals and non-goals are explicit
+- [ ] Security section is complete (all 7 areas addressed)
+- [ ] Alternatives are discussed
+- [ ] Diagrams illustrate complex flows
+- [ ] Code examples are concrete and in the correct language
+- [ ] Implementation phases are defined
+- [ ] Testing strategy covers all levels
+- [ ] File follows naming convention
+
+## ToolHive Architecture Summary
+
+### Platform Overview
+
+ToolHive is a **platform** for MCP server management (not just a container runner):
+
+- **Proxy layer** with middleware (auth, authz, audit, rate limiting)
+- **Security** by default (network isolation, permission profiles)
+- **Aggregation** via Virtual MCP Server
+- **Registry** for curated MCP servers
+- **Multi-deployment**: Local (CLI/UI) and Kubernetes (operator)
+
+### Key Binaries
+
+| Binary | Location | Purpose |
+|--------|----------|---------|
+| `thv` | toolhive | Main CLI |
+| `thv-operator` | toolhive | Kubernetes operator |
+| `thv-proxyrunner` | toolhive | K8s proxy container |
+| `vmcp` | toolhive | Virtual MCP server (aggregation) |
+| `thv-registry-api` | toolhive-registry-server | Registry API server |
+
+### Transport Types
+
+- **stdio** - Standard input/output (requires protocol translation)
+- **SSE** - Server-Sent Events (HTTP, transparent proxy)
+- **streamable-http** - HTTP streaming (transparent proxy)
+
+### Design Principles
+
+1. Platform abstraction over direct execution
+2. Security by default (network isolation, permissions)
+3. Extensibility through middleware
+4. Cloud-native (K8s operators, containers)
+5. RunConfig as portable API contract
+
+## Reference Files
+
+- Template: `rfcs/0000-template.md`
+- Contributing guide: `CONTRIBUTING.md`
+- Existing RFCs: `rfcs/THV-*.md`


### PR DESCRIPTION
## Summary
- Add `write-rfc` skill to guide users through creating high-quality RFCs following ToolHive conventions
- Add `review-rfc` skill to help review RFCs against quality standards, security requirements, and architectural alignment

## Details

### write-rfc Skill
Guides users through the RFC writing process:
- Gathering requirements (problem statement, target repo, scope)
- Researching the ecosystem via GitHub MCP tools
- Drafting with proper template structure
- Including required security considerations
- Following naming conventions

### review-rfc Skill
Provides comprehensive RFC review guidance:
- Structure and completeness checklist
- Security review (critical) with 8 required areas
- Technical accuracy verification
- Diagrams and examples quality
- Feasibility and impact assessment
- Standardized review output format

Both skills include:
- ToolHive architecture context and terminology
- Links to relevant documentation
- Guidance on using GitHub MCP tools to fetch context

## Test plan
- [ ] Test `/write-rfc` skill invocation
- [ ] Test `/review-rfc` skill invocation
- [ ] Verify skills appear in Claude Code's available skills list

🤖 Generated with [Claude Code](https://claude.com/claude-code)