### PR TITLE
RFC-0023: Add CRD and application config unification section

### DIFF
--- a/rfcs/THV-0023-crd-v1beta1-optimization.md
+++ b/rfcs/THV-0023-crd-v1beta1-optimization.md
@@ -705,7 +705,7 @@ For example, with `VirtualMCPServer` & `MCPTelemetryConfig` this pattern would l
    }
    ```
 
-3. **The VirtualMCPServer supports a reference, the config supports literal**:
+3. **The VirtualMCPServerSpec supports a reference, the config supports a literal**:
 
    ```go
    // In pkg/vmcp/config/config.go
@@ -719,7 +719,7 @@ For example, with `VirtualMCPServer` & `MCPTelemetryConfig` this pattern would l
        // ... other fields
    }
    ```
-   Remember, the `VirtualMCPServer` fully embeds the application config in its CRD. The above snippet simultaneously demonstrates adding support for a reference in the CRD and the equivalent type to
+   Recall, the `VirtualMCPServerSpec` fully embeds the application config in its CRD. The above snippet simultaneously demonstrates adding support for a reference in the CRD and the equivalent type to
    the application config. For the example above, the controller resolves `TelemetryRef` and populates `Telemetry` before passing to the server.
    
 


### PR DESCRIPTION
Add a new section addressing how net-new CRD spec types relate to application config structures, motivated by Issue #3125.

Key additions:
- Problem statement covering configuration pipeline complexity, silent bugs from translation layers, documentation divergence, and testing limitations
- Options comparison table contrasting separate vs unified types
- Proposal recommending new CRDs use the same types as application configs, with VirtualMCPServer and MCPTelemetryConfig as examples

Updated for consistency:
- Added #3125 to Related Issues
- Added unified types goal to Goals section
- Updated Summary to mention unified CRD/config types
- Updated Implementation Plan to reflect unified types approach