### PR TITLE
RFC: Embedded Authorization Server in Proxy Runner

### DIFF
--- a/rfcs/THV-0031-auth-server-integration.md
+++ b/rfcs/THV-0031-auth-server-integration.md
@@ -1,6 +1,6 @@
 # RFC-0031: Embedded Authorization Server in Proxy Runner
 
-- **Status**: Draft
+- **Status**: Accepted
 - **Author(s)**: @tgrunnagle
 - **Created**: 2026-01-27
 - **Last Updated**: 2026-01-27
@@ -583,6 +583,7 @@ None - all design questions resolved.
 | Date | Reviewer | Decision | Notes |
 |------|----------|----------|-------|
 | 2026-01-27 | TBD | Draft | Initial submission |
+| 2026-01-28 | @jhrozek | Accepted | |
 
 ### Implementation Tracking
 


### PR DESCRIPTION
## Summary

This RFC proposes integrating ToolHive's authorization server (`pkg/authserver/`) directly into the proxy runner process for Kubernetes deployments. This enables MCP servers to authenticate users via upstream identity providers (Okta, Azure AD, etc.) and issue tokens for MCP access.

## Key Changes

- **New CRD type**: `embeddedAuthServer` added to `MCPExternalAuthConfig`
- **Volume-based secrets**: Signing keys and HMAC secrets mounted as files (not env vars)
- **Key rotation support**: Multiple signing keys and HMAC secrets for graceful rotation
- **Upstream IDP integration**: OIDC (with discovery) and OAuth2 (explicit endpoints)

## Design Highlights

| Aspect | Decision |
|--------|----------|
| Deployment model | In-process with proxy runner (not standalone) |
| Secrets handling | Volume mounts with 0400 permissions |
| Key rotation | List-based (first = active, rest = fallback) |
| Storage | Memory-only (single replica limitation) |

## Security Benefits

- **Per-workload isolation**: Compromised proxy affects only one MCP server
- **No centralized auth**: Avoids single point of compromise for all workloads
- **Ephemeral tokens**: Lost on pod restart, no persistent state

## Implementation Phases

1. CRD type additions and webhook validation
2. Controller volume generation helpers
3. RunConfig extension for auth server config
4. Proxy runner integration with auth server lifecycle
5. Transport layer route mounting

## Files Changed

- `cmd/thv-operator/api/v1alpha1/mcpexternalauthconfig_types.go` - New CRD types
- `cmd/thv-operator/pkg/controllerutil/authserver.go` - Volume generation (new)
- `pkg/runner/config.go` - RunConfig extension
- `pkg/runner/authserver.go` - Auth server wrapper (new)
- `pkg/runner/runner.go` - Integration
- `pkg/transport/http.go` - Route mounting
