### PR TITLE
Add SECURITY.md for RFC repository

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+The ToolHive community takes security seriously! We appreciate your efforts to
+disclose your findings responsibly and will make every effort to acknowledge
+your contributions.
+
+## Scope
+
+This repository contains RFCs (Request for Comments) and design documents for
+the ToolHive ecosystem. While RFCs themselves do not contain executable code,
+security considerations in RFC designs are important.
+
+For security vulnerabilities in ToolHive implementations, please report them to
+the appropriate repository:
+
+- [ToolHive CLI](https://github.com/stacklok/toolhive/security/advisories/new)
+- [ToolHive Registry Server](https://github.com/stacklok/toolhive-registry-server/security/advisories/new)
+
+## Reporting a vulnerability
+
+If you discover a security issue in an RFC design that could lead to
+vulnerabilities in implementations, please use the GitHub Security Advisory
+["Report a Vulnerability"](https://github.com/stacklok/toolhive-rfcs/security/advisories/new)
+tab.
+
+If you are unable to access GitHub you can also email us at
+[security@stacklok.com](mailto:security@stacklok.com).
+
+Include:
+
+- The RFC number and title affected
+- Description of the security concern
+- Potential impact if the design is implemented as-is
+- Suggested mitigations or design changes
+
+### Contacting the ToolHive security team
+
+Contact the team by sending email to
+[security@stacklok.com](mailto:security@stacklok.com).
+
+## Disclosures
+
+### Private disclosure processes
+
+The ToolHive community asks that all suspected vulnerabilities be handled in
+accordance with the
+[Responsible Disclosure model](https://en.wikipedia.org/wiki/Responsible_disclosure).
+
+### Public disclosure processes
+
+If anyone knows of a publicly disclosed security vulnerability please
+IMMEDIATELY email [security@stacklok.com](mailto:security@stacklok.com) to
+inform us about the vulnerability so that we may start the patch, release, and
+communication process.


### PR DESCRIPTION
## Summary

- Adds security policy tailored for the RFC repository
- Directs implementation vulnerabilities to appropriate repos (toolhive CLI, registry server)
- Covers how to report security concerns in RFC designs
- Maintains contact info and responsible disclosure guidelines

## Test plan

- [ ] Verify links to security advisory pages work
- [ ] Confirm email contact is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)