### PR TITLE
Update THV-0057 key format to prevent cross-type collisions

### DIFF
--- a/rfcs/THV-0057-rate-limiting.md
+++ b/rfcs/THV-0057-rate-limiting.md
@@ -181,9 +181,11 @@ Per-user limits work identically — each user gets their own bucket, keyed by i
 - Global per-prompt: `thv:rl:{namespace}:{server}:global:prompt:{promptName}`
 - Global per-resource: `thv:rl:{namespace}:{server}:global:resource:{resourceName}`
 - Per-user: `thv:rl:{namespace}:{server}:user:{userId}`
-- Per-user per-tool: `thv:rl:{namespace}:{server}:user:{userId}:tool:{toolName}`
-- Per-user per-prompt: `thv:rl:{namespace}:{server}:user:{userId}:prompt:{promptName}`
-- Per-user per-resource: `thv:rl:{namespace}:{server}:user:{userId}:resource:{resourceName}`
+- Per-user per-tool: `thv:rl:{namespace}:{server}:user-tool:{toolName}:{userId}`
+- Per-user per-prompt: `thv:rl:{namespace}:{server}:user-prompt:{promptName}:{userId}`
+- Per-user per-resource: `thv:rl:{namespace}:{server}:user-resource:{resourceName}:{userId}`
+
+Per-user per-operation keys use distinct prefixes (`user-tool:`, `user-prompt:`, `user-resource:`) rather than nesting under `user:{userId}:tool:...` to prevent key collisions when a `userId` contains delimiter characters (e.g., `:tool:`). The operation name precedes the userId so that the variable-length userId is always the terminal component.
 
 The `{namespace}` and `{server}` components are derived from the CRD metadata at middleware initialization time, never from per-request input.
 


### PR DESCRIPTION
## Summary

The implementation of per-user rate limiting (stacklok/toolhive#4692) revealed that the RFC's Redis key format for per-user per-operation keys could produce collisions when a `userId` contains delimiter characters like `:tool:`.

- Update per-user per-operation key format to use distinct prefixes (`user-tool:`, `user-prompt:`, `user-resource:`) instead of nesting under `user:{userId}:tool:...`
- Place the operation name before the userId so the variable-length userId is always the terminal key component
- Add explanatory note about why the format uses distinct prefixes

The original format `user:{userId}:tool:{toolName}` collides with server-level `user:{userId}` when a userId literally contains `:tool:{toolName}`. While unlikely in practice (JWT `sub` claims are typically UUIDs or emails), the distinct prefix approach eliminates the structural ambiguity entirely.

Generated with [Claude Code](https://claude.com/claude-code)